### PR TITLE
Libgit2 0.22.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 build
+*.cmake
+CMakeCache.txt
+CMakeFiles/*
+Makefile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ include_directories(${LUA_INCLUDE_DIR})
 
 ## LibGit2
 include(FindPkgConfig)
-pkg_search_module(GIT2 REQUIRED libgit2=0.17.0)
+pkg_search_module(GIT2 REQUIRED libgit2=0.22.3)
 add_definitions(${GIT2_CFLAGS})
 link_directories(${GIT2_LIBRARY_DIRS})
 include_directories(${GIT2_INCLUDE_DIRS})


### PR DESCRIPTION
I've upgraded the required `libgit2` version from `0.17.0` to `0.22.3` as I was unable to get version `0.17.0` from [Homebrew](http://brew.sh/). `cmake CMakeLists.txt` executed just fine after (but didn't before).
